### PR TITLE
container内でconsole利用できるように修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby File.read(File.expand_path('../.ruby-version', __FILE__)).strip
+ruby '2.4.0'
 source 'https://rubygems.org'
 
 ENV['NOKOGIRI_USE_SYSTEM_LIBRARIES'] = 'YES'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,4 +204,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.15.0
+   1.16.1

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,17 +1,27 @@
 version: '2'
 
 services:
-  rails: &rails
+  datastore:
+    image: busybox
+    volumes:
+      - bundle_install:/myapp/vendor/bundle
+      - bundle:/myapp/.bundle
+      - bundle_cache:/usr/local/bundle
+  web:
     depends_on:
       - db
     volumes:
       - .:/myapp
+    volumes_from:
+      - datastore
     build:
       context: .
       dockerfile: dockerfiles/Dockerfile-rails.dev
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     ports:
       - '3000:3000'
+    stdin_open: true
+    tty: true
 
   db:
     image: mysql:5.6
@@ -21,3 +31,15 @@ services:
       MYSQL_PASSWORD: password
     ports:
       - "3306:3306"
+    volumes_from:
+      - datastore
+    volumes:
+      - ./db/mysql_data:/var/lib/mysql
+
+volumes:
+  bundle_install:
+    driver: local
+  bundle:
+    driver: local
+  bundle_cache:
+    driver: local

--- a/dockerfiles/Dockerfile-rails.dev
+++ b/dockerfiles/Dockerfile-rails.dev
@@ -5,7 +5,14 @@ RUN mkdir -p $APP_HOME
 WORKDIR $APP_HOME
 
 RUN apt-get update -qq && apt-get install -y git build-essential libpq-dev nodejs
+RUN gem install bundler
+RUN bundle config build.nokogiri --use-system-libraries
 
 # setup Rails
-ADD . $APP_HOME
+COPY Gemfile \
+     Gemfile.lock \
+     $APP_HOME/
+
+ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
+    BUNDLE_JOBS=4
 RUN bundle install


### PR DESCRIPTION
## このPRについて

issue #3 対応

## 参考にした情報

[開発しやすいRails on Docker環境の作り方](https://qiita.com/joker1007/items/9f54e763ae640f757cfb)

[Springが動くRails+MySQLなAPIサーバの開発環境をDocker Composeで作る](http://blog.kymmt.com/entry/compose-and-rails-api-with-spring)

```
［2017-06-11 追記］bundle install する場所について
bundle install を Dockerfile に書くと、イメージのビルド時にインストールされたgemがイメージに入ります。この時点ではgemを保存するVolumeが設定されていないのですが、docker-compose コマンド経由でコンテナを起動すると、Volumeがgem保存先にマウントされます。このVolumeが上述の説明で使っている名前付きボリュームだと、マウント先に存在するファイルはVolumeへコピーされます*3。

しかし、コンテナ起動前後でgemの保存の仕組みが変わるのはわかりにくいです。Dockerfile 内に bundle install を書くのではなく docker-compose run --rm app bundle install のように明示的にVolumeへgemをインストールする、という方法のほうがわかりやすそうです。
```

https://github.com/rails/spring/issues/545

> If we put the bundler config in the default location and unset BUNDLE_APP_CONFIG, the binstub now works:

とか以下あたり
```
Workaround
Do not use BUNDLE_APP_CONFIG.

Note that Circle CI sets the BUNDLE_APP_CONFIG variable by default in its ruby:2.4.2-node-browsers docker image, so many developers could run into this bug.
```

introduction of BUNDLE_APP_CONFIG leads to unexpected behavior for 'statically' bundled apps #129

https://github.com/docker-library/ruby/issues/129